### PR TITLE
fix: Expansion detector loop

### DIFF
--- a/src/mq/queues/systemProcessing/stateDetectors/ExpansionDetector.ts
+++ b/src/mq/queues/systemProcessing/stateDetectors/ExpansionDetector.ts
@@ -36,6 +36,8 @@ export class ExpansionDetector extends BaseStateDetector {
         })
         await Redis.expire(expansionRedisKey, EXPANSION_REDIS_EXPIRATION)
       }
+      // Do not report expansion ending if it's pending/active now
+      return
     }
 
     if (isExpansionEnding) {


### PR DESCRIPTION
- fixed edge case when expansion messages were continuously sent
- caused by system that was in expansion, then it was processed again after some time - expansion has ended and new expansion has started